### PR TITLE
Account for inconsistent naming convention

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -36,20 +36,26 @@ class Transaction
     }
 
     /**
+     * NOTE: Account for LimeLight's inconsistent response camel/snake case
+     *
      * @param array $response
      * @throws LimeLightCRMTransactionException
      */
     public function checkResponse(array $response)
     {
-        $exception = null;
+        $exception = $responses = null;
 
         if (isset($response['responseCode'])) {
             $responses = explode(',', $response['responseCode']);
+        }
 
-            foreach ($responses as $code) {
-                if (!in_array($code, [100])) {
-                    $exception = new LimeLightCRMTransactionException($code, $exception, $response);
-                }
+        if (isset($response['response_code'])) {
+            $responses = explode(',', $response['response_code']);
+        }
+
+        foreach ($responses as $code) {
+            if (!in_array($code, [100])) {
+                $exception = new LimeLightCRMTransactionException($code, $exception, $response);
             }
         }
 

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -53,9 +53,11 @@ class Transaction
             $responses = explode(',', $response['response_code']);
         }
 
-        foreach ($responses as $code) {
-            if (!in_array($code, [100])) {
-                $exception = new LimeLightCRMTransactionException($code, $exception, $response);
+        if (isset($responses)) {
+            foreach ($responses as $code) {
+                if (!in_array($code, [100])) {
+                    $exception = new LimeLightCRMTransactionException($code, $exception, $response);
+                }
             }
         }
 


### PR DESCRIPTION
LimeLight has been inconsistent with their naming conventions when returning the response.

To account for these inconsistencies, use which ever is set when checking the response.